### PR TITLE
drastically simplified the code base using components

### DIFF
--- a/code/usb-audio/esp-idf/.vscode/settings.json
+++ b/code/usb-audio/esp-idf/.vscode/settings.json
@@ -4,5 +4,10 @@
     "target/esp32s3.cfg"
   ],
   "idf.port": "/dev/tty.wchusbserial58FA0405211",
-  "idf.flashType": "UART"
+  "idf.flashType": "UART",
+  "files.associations": {
+    "usb_device_uac.h": "c",
+    "tusb.h": "c",
+    "i2s_std.h": "c"
+  }
 }

--- a/code/usb-audio/esp-idf/components/dac/CMakeLists.txt
+++ b/code/usb-audio/esp-idf/components/dac/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "src/dac.c"
+                       INCLUDE_DIRS "include"
+                       REQUIRES driver)

--- a/code/usb-audio/esp-idf/components/dac/include/dac.h
+++ b/code/usb-audio/esp-idf/components/dac/include/dac.h
@@ -1,0 +1,9 @@
+#ifndef DAC_H
+#define DAC_H
+#include <stdio.h>
+#include "esp_err.h"
+
+void dac_init(void);
+esp_err_t dac_write(int16_t *samples_in_16b, size_t q_samples, size_t *q_samples_written);
+
+#endif // DAC_H

--- a/code/usb-audio/esp-idf/components/dac/src/dac.c
+++ b/code/usb-audio/esp-idf/components/dac/src/dac.c
@@ -1,0 +1,95 @@
+static const char *TAG = "dac";
+
+/* -----------------------------------------------------------------------------------------------------------------------------
+
+Main
+
+----------------------------------------------------------------------------------------------------------------------------- */
+
+#include "dac.h"
+#include <stdio.h>
+#include "esp_err.h"           // error checker
+#include "esp_log.h"           // logger
+#include "driver/i2s_std.h"    // I2S driver for the DAC
+#include "freertos/FreeRTOS.h" // General OS stuff
+
+/* -----------------------------------------------------------------------------------------------------------------------------
+
+Config
+
+----------------------------------------------------------------------------------------------------------------------------- */
+
+#define I2S_PORT I2S_NUM_0 // Use I2S0
+#define BCLK GPIO_NUM_14
+#define DATA_OUT GPIO_NUM_13
+#define WORD_SELECT GPIO_NUM_12
+
+/* -----------------------------------------------------------------------------------------------------------------------------
+
+Globals
+
+----------------------------------------------------------------------------------------------------------------------------- */
+
+i2s_chan_handle_t i2s_dac_tx_handle;
+
+/* -----------------------------------------------------------------------------------------------------------------------------
+
+Init DAC
+
+----------------------------------------------------------------------------------------------------------------------------- */
+
+void dac_init()
+{
+
+  // Step 1: Define the I2S channel configuration
+  i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(I2S_PORT, I2S_ROLE_MASTER);
+
+  // buffer_size = dma_frame_num * slot_num * slot_bit_width / 8
+  chan_cfg.dma_desc_num = 6;    // default 6
+  chan_cfg.dma_frame_num = 512; // default 240
+  ESP_ERROR_CHECK(i2s_new_channel(&chan_cfg, &i2s_dac_tx_handle, NULL));
+
+  // Step 2: Define the standard mode configuration
+  i2s_std_config_t std_cfg = {
+      .clk_cfg = I2S_STD_CLK_DEFAULT_CONFIG(CONFIG_UAC_SAMPLE_RATE),
+      .slot_cfg = I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_STEREO),
+      .gpio_cfg = {
+          .mclk = I2S_GPIO_UNUSED, // PCM5102a doesn't need a clock
+          .bclk = BCLK,
+          .ws = WORD_SELECT,
+          .dout = DATA_OUT,
+          .din = I2S_GPIO_UNUSED, // Not used in TX mode
+      },
+  };
+
+  // Step 3: Initialize the I2S channel with the standard mode configuration
+  ESP_ERROR_CHECK(i2s_channel_init_std_mode(i2s_dac_tx_handle, &std_cfg));
+
+  // Step 4: Enable the I2S channel
+  ESP_ERROR_CHECK(i2s_channel_enable(i2s_dac_tx_handle));
+}
+
+/* -----------------------------------------------------------------------------------------------------------------------------
+
+DAC methods
+
+----------------------------------------------------------------------------------------------------------------------------- */
+
+/*
+Writes a buffer of 16 bit samples.
+This is a blocking call, meaning that if I2S buffers are busy
+it will wait until they become available (or time out).
+It returns an error if I2S is not ready.
+It updates the number of samples written via q_samples_written
+*/
+esp_err_t dac_write(int16_t *samples_in_16b, size_t q_samples, size_t *q_samples_written)
+{
+  size_t q_bytes = q_samples * 2; // 16 bits is 2 bytes
+  size_t bytes_written;
+  esp_err_t err = i2s_channel_write(i2s_dac_tx_handle, samples_in_16b, q_bytes, &bytes_written, portMAX_DELAY);
+  if (q_samples_written)
+  {
+    *q_samples_written = bytes_written / 2;
+  }
+  return err;
+}

--- a/code/usb-audio/esp-idf/components/usb_audio_interface/CMakeLists.txt
+++ b/code/usb-audio/esp-idf/components/usb_audio_interface/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "src/usb_audio_interface.c"
+                       INCLUDE_DIRS "include"
+                       REQUIRES driver)

--- a/code/usb-audio/esp-idf/components/usb_audio_interface/idf_component.yml
+++ b/code/usb-audio/esp-idf/components/usb_audio_interface/idf_component.yml
@@ -1,0 +1,7 @@
+dependencies:
+  idf: '>=5.1'
+  usb_device_uac:
+    version: 1.*
+targets:
+- esp32s3
+version: 0.0.0

--- a/code/usb-audio/esp-idf/components/usb_audio_interface/include/usb_audio_interface.h
+++ b/code/usb-audio/esp-idf/components/usb_audio_interface/include/usb_audio_interface.h
@@ -1,0 +1,17 @@
+
+#ifndef USB_AUDIO_INTERFACE_H
+#define USB_AUDIO_INTERFACE_H
+#include <stdio.h>
+#include <stdint.h>
+#include "esp_err.h"
+
+typedef esp_err_t (*usb_audio_interface_output_cb_t)(int16_t *samples_in_16b, size_t q_samples);
+
+typedef struct
+{
+  usb_audio_interface_output_cb_t freshly_baked_samples_cb; /*!< callback function that is expected to do something with incoming samples */
+} usb_audio_interface_config_t;
+
+esp_err_t usb_audio_interface_init(usb_audio_interface_config_t *config);
+
+#endif // USB_AUDIO_INTERFACE_H

--- a/code/usb-audio/esp-idf/components/usb_audio_interface/src/usb_audio_interface.c
+++ b/code/usb-audio/esp-idf/components/usb_audio_interface/src/usb_audio_interface.c
@@ -1,0 +1,106 @@
+static const char *TAG = "usb_audio_interface";
+
+/* -----------------------------------------------------------------------------------------------------------------------------
+
+Main
+
+----------------------------------------------------------------------------------------------------------------------------- */
+
+#include "usb_audio_interface.h"
+#include "usb_device_uac.h"    // USB audio
+#include "freertos/FreeRTOS.h" // General OS stuff
+#include "esp_log.h"           // logger
+#include "math.h"              // to calculate log volume curve
+
+/* -----------------------------------------------------------------------------------------------------------------------------
+
+Globals
+
+----------------------------------------------------------------------------------------------------------------------------- */
+
+static usb_audio_interface_output_cb_t freshly_baked_samples_cb;
+static volatile float usb_volume = 0;          // [0:1] multiplier
+static volatile float usb_pre_mute_volume = 0; // what was the volume before muting. Will return to this after unmuting.
+
+/* -----------------------------------------------------------------------------------------------------------------------------
+
+Callbacks to react to USB events
+
+----------------------------------------------------------------------------------------------------------------------------- */
+
+// Adjust volume of USB stream
+static void uac_device_set_volume_cb(uint32_t volume, void *arg)
+{
+  // Volume is 0-100. Map it to 0.0 - 1.0 logarithmically.
+  if (volume == 0)
+  {
+    usb_volume = 0.0f;
+  }
+  else
+  {
+    usb_volume = powf(10, (float)volume / 100.0f * 2.5f - 2.5f); // Maps 0-100 to ~0.003 - 1.0
+  }
+  ESP_LOGI(TAG, "Volume Set: %u -> Scaled: %f", volume, usb_volume);
+}
+
+// Mute USB stream
+static void uac_device_set_mute_cb(uint32_t mute, void *arg)
+{
+  if (mute)
+  {
+    usb_pre_mute_volume = usb_volume;
+    usb_volume = 0;
+  }
+  else
+  {
+    usb_volume = usb_pre_mute_volume;
+  }
+  ESP_LOGI(TAG, "uac_device_set_mute_cb: %" PRIu32 "", mute);
+}
+
+/*
+ Handle incoming samples (Mac > USB > ESP)
+ This callback will be passed to TinyUSB.
+ It's basically a wrapper around the callback provided by the user,
+ but with some nice stuff like:
+ - transforms bytes to 16 bit samples
+ - applies volume adjustment
+ */
+static esp_err_t uac_device_output_cb(uint8_t *buffer_8b, size_t q_bytes, void *arg)
+{
+  // buf contains interleaved stereo samples in 16-bit PCM format
+  int16_t *samples_in_16b = (int16_t *)buffer_8b; // Treat buffer as an array of 16-bit integers
+  size_t q_samples = q_bytes / 2;                 // 2 bytes for each 16 bit sample
+
+  if (freshly_baked_samples_cb)
+  {
+    for (size_t i = 0; i < q_samples; i++)
+    {
+      float scaled_sample = samples_in_16b[i] * usb_volume; // Apply volume
+      samples_in_16b[i] = (int16_t)scaled_sample;           // Convert back to int16
+    }
+    return freshly_baked_samples_cb(samples_in_16b, q_samples);
+  }
+  return ESP_OK;
+}
+
+/* -----------------------------------------------------------------------------------------------------------------------------
+
+Init USB audio interface
+
+----------------------------------------------------------------------------------------------------------------------------- */
+
+esp_err_t usb_audio_interface_init(usb_audio_interface_config_t *config)
+{
+  freshly_baked_samples_cb = config->freshly_baked_samples_cb;
+
+  uac_device_config_t uac_device_config = {
+      .output_cb = uac_device_output_cb, // receive audio from the host
+      .input_cb = NULL,                  // transfer audio to the host
+      .set_mute_cb = uac_device_set_mute_cb,
+      .set_volume_cb = uac_device_set_volume_cb,
+      .cb_ctx = NULL,
+  };
+
+  return uac_device_init(&uac_device_config);
+}

--- a/code/usb-audio/esp-idf/dependencies.lock
+++ b/code/usb-audio/esp-idf/dependencies.lock
@@ -52,6 +52,6 @@ dependencies:
 direct_dependencies:
 - espressif/usb_device_uac
 - idf
-manifest_hash: b1c5720d102c1bfdbfde21820851c00261bedbd99d0356b804b2beb390004c79
+manifest_hash: 363d29e8e5547c5dc5cc1a2ee668c43f4deca450545752efb6b7bf802367ca14
 target: esp32s3
 version: 2.0.0

--- a/code/usb-audio/esp-idf/main/usb-audio.c
+++ b/code/usb-audio/esp-idf/main/usb-audio.c
@@ -9,12 +9,13 @@ Libs
 #include "freertos/FreeRTOS.h" // General OS stuff
 #include "freertos/task.h"     // General OS stuff
 #include <stdio.h>
-#include "esp_err.h"        // error checker
-#include "esp_log.h"        // logger
-#include "driver/i2s_std.h" // I2S driver for the DAC
-#include "math.h"           // To calculate sinewave
-#include "usb_device_uac.h" // USB audio
-#include "tusb.h"
+#include "esp_err.h" // error checker
+#include "esp_log.h" // logger
+#include "math.h"    // To calculate sinewave
+
+// My modules to make my life easier
+#include "dac.h"                 // my module
+#include "usb_audio_interface.h" // my module
 
 /* -----------------------------------------------------------------------------------------------------------------------------
 
@@ -22,116 +23,19 @@ PIN LAYOUT
 
 ----------------------------------------------------------------------------------------------------------------------------- */
 
-#define I2S_PORT I2S_NUM_0 // Use I2S0
-#define BITS_PER_SAMPLE 16 // PCM bit depth - THIS IS NOT A VARIABLE! DON'T CHANGE IT!
-#define PI 3.14159265
-#define SINE_WAVE_FREQ 220 // A4 note (440 Hz)
-
-/* -----------------------------------------------------------------------------------------------------------------------------
-
-I2S DAC
-
------------------------------------------------------------------------------------------------------------------------------ */
-i2s_chan_handle_t i2s_dac_tx_handle;
-
-/* -----------------------------------------------------------------------------------------------------------------------------
-
-USB audio
-
------------------------------------------------------------------------------------------------------------------------------ */
-
-#define OUTPUT_BUFFER_STEREO_SAMPLES 128
-#define OUTPUT_BUFFER_LENGTH (OUTPUT_BUFFER_STEREO_SAMPLES * 2)
-static float output_buffer[OUTPUT_BUFFER_LENGTH];
-volatile uint16_t output_buffer_write_index = 0;
-volatile uint16_t output_buffer_dac_read_index = 0;
-
-static void init_output_buffer(void) {
-  for (output_buffer_write_index = 0; output_buffer_write_index < OUTPUT_BUFFER_LENGTH; output_buffer_write_index++) {
-    output_buffer[output_buffer_write_index] = 0;
-  }
-  output_buffer_write_index = 0;
-  return;
-}
-
-volatile bool receiving_usb_audio = false;
-volatile float usb_volume = 0;          // [0:1] multiplier
-volatile float usb_pre_mute_volume = 0; // what was the volume before muting. Will return to this after unmuting.
-
-static void uac_device_set_mute_cb(uint32_t mute, void *arg)
+volatile uint32_t stereo_samples_sent = 0;
+static esp_err_t pipe_usb_audio_to_dac(int16_t *samples_in_16b, size_t q_samples)
 {
-  if (mute)
+
+  size_t q_samples_written;
+  ESP_ERROR_CHECK_WITHOUT_ABORT(dac_write(samples_in_16b, q_samples, &q_samples_written));
+
+  if (q_samples_written != q_samples)
   {
-    usb_pre_mute_volume = usb_volume;
-    usb_volume = 0;
-  }
-  else
-  {
-    usb_volume = usb_pre_mute_volume;
-  }
-  ESP_LOGI(TAG, "uac_device_set_mute_cb: %" PRIu32 "", mute);
-}
-
-static void uac_device_set_volume_cb(uint32_t volume, void *arg)
-{
-    // Volume is 0-100, we map it to 0.0 - 1.0 in a logarithmic way
-    if (volume == 0) {
-      usb_volume = 0.0f;
-    } else {
-      usb_volume = powf(10, (float)volume / 100.0f * 2.0f - 2.0f); // Maps 0-100 to ~0.01 - 1.0
-    }
-    ESP_LOGI(TAG, "Volume Set: %u -> Scaled: %f", volume, usb_volume);
-}
-
-// Invoked when device is mounted
-static void uac_usb_ok_cb(void *arg)
-{
-  uac_device_set_mute_cb(1, NULL);
-  receiving_usb_audio = true;
-  ESP_LOGI(TAG, "USB OK 🔥");
-  // Mute audio for a few seconds to avoid weird sounds while the i2s driver restarts
-  ESP_ERROR_CHECK_WITHOUT_ABORT(i2s_channel_enable(i2s_dac_tx_handle));
-  vTaskDelay(pdMS_TO_TICKS(1000));
-  uac_device_set_mute_cb(0, NULL);
-}
-
-// Invoked when device is unmounted
-static void uac_usb_disconnected_cb(void *arg)
-{
-  receiving_usb_audio = false;
-  ESP_LOGI(TAG, "USB disconnected 💩");
-  ESP_ERROR_CHECK_WITHOUT_ABORT(i2s_channel_disable(i2s_dac_tx_handle));
-}
-
-volatile uint32_t samples_sent = 0;
-static esp_err_t uac_device_output_cb(uint8_t *buf, size_t len, void *arg)
-{
-  if(!receiving_usb_audio) {
-    return ESP_OK;
+    ESP_LOGW(TAG, "Received %d samples from USB, wrote %d to I2S. Drift!", q_samples, q_samples_written);
   }
 
-  size_t bytes_written;
-
-  // buf contains interleaved stereo samples in 16-bit PCM format
-  int16_t *samples = (int16_t *)buf; // Treat buffer as an array of 16-bit integers
-  size_t num_samples = len / 2; // 2 bytes for each 16 bit sample
-
-  for (size_t i = 0; i < num_samples; i++)
-  {
-    float scaled_sample = samples[i] * usb_volume; // Apply volume
-    samples[i] = (int16_t)scaled_sample;           // Convert back to int16
-  }
-
-
-  // Send samples to I2S
-  i2s_channel_write(i2s_dac_tx_handle, samples, len, &bytes_written, portMAX_DELAY);
-
-  if (bytes_written != len)
-  {
-    ESP_LOGW(TAG, "Received %d bytes from USB, wrote %d bytes to I2S. Drift!", len, bytes_written);
-  }
-
-  samples_sent += bytes_written / 2 / 2; // 2 bytes per channel (16 bits), 2 channels (stereo)
+  stereo_samples_sent += q_samples_written / 2; // 2 channels (stereo)
   // ESP_LOGI(TAG, "Received %d bytes from USB, wrote %d bytes to I2S. Samples: %d", len, bytes_written, num_samples);
 
   return ESP_OK;
@@ -139,118 +43,19 @@ static esp_err_t uac_device_output_cb(uint8_t *buf, size_t len, void *arg)
 
 /* -----------------------------------------------------------------------------------------------------------------------------
 
-Helpers
-
------------------------------------------------------------------------------------------------------------------------------ */
-
-void generate_sine_wave()
-{
-  size_t bytes_written;
-  int16_t sample[2];
-  int amplitude = 32767 / 6; // Max value for 16-bit audio (limit to 25% so I don't break my ears)
-
-  for (int i = 0; i < CONFIG_UAC_SAMPLE_RATE; i++)
-  {
-    float theta = (2.0 * PI * SINE_WAVE_FREQ * i) / CONFIG_UAC_SAMPLE_RATE;
-    int16_t value = (int16_t)(amplitude * sin(theta));
-
-    // Stereo sample (L, R)
-    sample[0] = value;
-    sample[1] = value;
-
-    ESP_ERROR_CHECK(i2s_channel_write(i2s_dac_tx_handle, sample, sizeof(sample), &bytes_written, portMAX_DELAY));
-  }
-}
-
-/* -----------------------------------------------------------------------------------------------------------------------------
-
-Setup
-
------------------------------------------------------------------------------------------------------------------------------ */
-
-void init_i2s_dac_driver()
-{
-
-  // Step 1: Define the I2S channel configuration
-  i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(I2S_NUM_0, I2S_ROLE_MASTER);
-
-  // buffer_size = dma_frame_num * slot_num * slot_bit_width / 8
-  chan_cfg.dma_desc_num = 6;    // default 6
-  chan_cfg.dma_frame_num = 256; // default 240
-  ESP_ERROR_CHECK(i2s_new_channel(&chan_cfg, &i2s_dac_tx_handle, NULL));
-
-  // Step 2: Define the standard mode configuration
-  i2s_std_config_t std_cfg = {
-      .clk_cfg = I2S_STD_CLK_DEFAULT_CONFIG(CONFIG_UAC_SAMPLE_RATE),
-      .slot_cfg = I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_STEREO),
-      .gpio_cfg = {
-          .mclk = I2S_GPIO_UNUSED, // Use I2S_GPIO_UNUSED if not used
-          .bclk = GPIO_NUM_14,
-          .ws = GPIO_NUM_12,
-          .dout = GPIO_NUM_13,
-          .din = I2S_GPIO_UNUSED, // Not used in TX mode
-      },
-  };
-
-  // Step 3: Initialize the I2S channel with the standard mode configuration
-  ESP_ERROR_CHECK(i2s_channel_init_std_mode(i2s_dac_tx_handle, &std_cfg));
-
-  // Step 4: Enable the I2S channel
-  ESP_ERROR_CHECK(i2s_channel_enable(i2s_dac_tx_handle));
-}
-
-void init_usb_uac_audio_device()
-{
-  uac_device_config_t config = {
-      .output_cb = uac_device_output_cb, // receive audio from the host
-      .input_cb = NULL,                  // transfer audio to the host
-      .set_mute_cb = uac_device_set_mute_cb,
-      .set_volume_cb = uac_device_set_volume_cb,
-      .cb_ctx = NULL,
-      .uac_usb_ok_cb = uac_usb_ok_cb,
-      .uac_usb_disconnected_cb = uac_usb_disconnected_cb,
-  };
-
-  uac_device_init(&config);
-}
-
-/* -----------------------------------------------------------------------------------------------------------------------------
-
 Main
 
 ----------------------------------------------------------------------------------------------------------------------------- */
-void monitor_audio_sync(void *arg)
-{
-  while (1)
-  {
-    if (!receiving_usb_audio)
-    {
-      vTaskDelay(10);
-      continue;
-    }
-    static uint32_t last_samples_sent = 0;
-    uint32_t expected_samples = 48000; // We should have played this much in 1 sec
-    uint32_t actual_samples_sent = samples_sent - last_samples_sent;
-
-    ESP_LOGI(TAG, "Expected: %d, Actual Sent: %d, Diff: %d",
-             expected_samples, actual_samples_sent, actual_samples_sent - expected_samples);
-
-    last_samples_sent = samples_sent;
-    vTaskDelay(pdMS_TO_TICKS(1000)); // Run every 1 second
-  }
-}
 
 void app_main(void)
 {
-  // Fill the audio output buffer with zeros
-  init_output_buffer();
 
-  // Start the I2S driver to send audio to the DAC
-  init_i2s_dac_driver();
+  // Start DAC
+  dac_init();
 
   // Start the USB driver to receive audio
-  init_usb_uac_audio_device();
-
-  // monitoring
-  xTaskCreate(monitor_audio_sync, "monitor_audio_sync", 4 * 1024, NULL, 1, NULL);
+  usb_audio_interface_config_t usb_audio_interface_config = {
+      .freshly_baked_samples_cb = pipe_usb_audio_to_dac,
+  };
+  usb_audio_interface_init(&usb_audio_interface_config);
 }


### PR DESCRIPTION
Ok, the code base is getting big. Time to refactor!
I've created 2 modules to encapsulate logic for **DAC** and **USB audio**.

**DAC**
Abstracts away all the I2S implementation and exposes a simple method to write 16bits samples.

**USB**
Abstracts away the TinyUSB configuration and volume settings. It exposes (well, it receives) a callback to notify the main program that there are new samples. The callback is conveniently called `freshly_baked_samples_cb`

Both components expose interfaces that deal with 16 bits audio samples. No need to deal with bytes.