### PR TITLE
docs: capture MIDI+Audio post-merge follow-up work

### DIFF
--- a/code/README.md
+++ b/code/README.md
@@ -11,3 +11,9 @@ Same as above.
 
 ## MIDI + Audio interface
 Contains a new ESP-IDF codebase for a single ESP32-S3 firmware exposing both USB MIDI and USB Audio output paths.
+
+### Follow-up work
+- Run hardware validation on macOS and Windows and capture latency/underrun behavior.
+- Implement runtime sample-rate switching in the I2S path when host sends USB Audio rate changes.
+- Define and implement handling for USB MIDI OUT messages coming from the host.
+- Expand bring-up docs with wiring details and reproducible validation steps.


### PR DESCRIPTION
## Summary
- add a Follow-up work section to `code/README.md` with the remaining MIDI+Audio hardening items
- align repo docs with the merged composite firmware state and call out next engineering steps
- mirror these backlog items as ordered Tasks so execution can continue in small, trackable units

## Technical Debt
- hardware validation is still pending on real devices/hosts
- runtime sample-rate switching and USB MIDI OUT behavior need dedicated implementation tasks