### PR TITLE
Add reproducible MIDI+Audio hardware validation report

### DIFF
--- a/code/midi-audio-interface/HARDWARE_VALIDATION.md
+++ b/code/midi-audio-interface/HARDWARE_VALIDATION.md
@@ -1,0 +1,52 @@
+# MIDI + Audio Hardware Validation Report
+
+This report tracks end-to-end validation of `code/midi-audio-interface/esp-idf` on real ESP32-S3 hardware.
+
+## Firmware under test
+
+- Branch: `feature/validate-midi-audio-hardware`
+- App path: `code/midi-audio-interface/esp-idf`
+- Target: ESP32-S3
+- USB profile: Composite USB Audio Output + USB MIDI
+- Audio format: 48 kHz, stereo, 16-bit PCM
+
+## Lab setup
+
+Fill this section before each run.
+
+- Board and revision:
+- External DAC model and wiring:
+- MIDI source device:
+- UART wiring details:
+- Host OS and version:
+- Test apps used (DAW, MIDI monitor, audio player):
+- Firmware commit SHA:
+
+## Validation matrix
+
+Use `PASS`, `FAIL`, or `PENDING`.
+
+| Test | macOS | Windows | Notes |
+| --- | --- | --- | --- |
+| Enumerates as composite Audio Output + MIDI | PENDING | PENDING | |
+| UART MIDI -> USB MIDI forwarding under sustained traffic | PENDING | PENDING | |
+| Pot/ADC CC generation stability (acceptable jitter only) | PENDING | PENDING | |
+| USB audio playback continuity to external DAC at 48 kHz stereo | PENDING | PENDING | |
+
+## Measurements
+
+- End-to-end MIDI latency:
+- End-to-end audio latency:
+- Buffer underruns observed:
+- Buffer overruns observed:
+- Host-specific quirks:
+
+## Defects and follow-ups
+
+List regressions or defects discovered during validation.
+
+1. None recorded yet.
+
+## Execution note for this branch
+
+This branch was prepared in a CI-like coding environment without direct access to physical ESP32-S3 hardware, external DAC, or macOS/Windows hosts. The checklist and report structure are complete, but hardware test rows remain `PENDING` until run in the lab.

--- a/code/midi-audio-interface/README.md
+++ b/code/midi-audio-interface/README.md
@@ -11,12 +11,13 @@ Target behavior:
 
 ## Current status
 
-This initial implementation sets up the new project structure and the end-to-end runtime pipeline for:
-- UART MIDI parsing and forwarding to USB MIDI
+The composite USB implementation is in place in `esp-idf/main/jammond-midi-audio.c` and includes:
+- USB Audio Output + USB MIDI descriptors using raw TinyUSB
+- UART MIDI forwarding to USB MIDI
 - Analog pot scanning and MIDI CC generation
-- DAC output task and ring buffer plumbing
+- USB audio ingestion and forwarding to an external DAC over I2S
 
-The remaining piece is wiring raw TinyUSB Audio class descriptors/callbacks in `main/jammond-midi-audio.c` so USB speaker packets are consumed directly from TinyUSB and pushed to the DAC ring buffer.
+Hardware validation is tracked in `HARDWARE_VALIDATION.md`.
 
 ## Why a new project
 
@@ -24,7 +25,7 @@ The remaining piece is wiring raw TinyUSB Audio class descriptors/callbacks in `
 
 ## Next execution order
 
-1. Add TinyUSB composite descriptor with Audio + MIDI interfaces.
-2. Implement TinyUSB Audio OUT receive callbacks and feed the ring buffer.
-3. Validate sample rate and endpoint sizing at 48k stereo, then expand to 96k if needed.
-4. Validate full device enumeration on macOS/Windows and MIDI merge behavior under load.
+1. Run full hardware validation on macOS and Windows (enumeration, MIDI forwarding, audio continuity).
+2. Add runtime audio sample-rate switching in the I2S path.
+3. Define and implement USB MIDI OUT handling policy.
+4. Write bring-up and validation guide for repeatable lab testing.


### PR DESCRIPTION
## Summary
- add `code/midi-audio-interface/HARDWARE_VALIDATION.md` with a reproducible lab setup section, validation matrix for macOS/Windows, and measurements/defects tracking
- update `code/midi-audio-interface/README.md` to reflect that composite USB MIDI+Audio is implemented and point to the hardware validation report
- align next-step ordering with thread backlog (hardware validation, sample-rate switching, MIDI OUT policy, bring-up docs)

## Technical debt / follow-up
- physical hardware validation is still pending because this environment has no attached ESP32-S3 + DAC + host matrix access
- required workflow commands `npm run build:dev` and `npm run dev` currently fail repository-wide due to missing `package.json`; if these are expected gates, add documented scripts or task-specific equivalents